### PR TITLE
fix: suppress Purchase Order creation error from Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -603,14 +603,6 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 	}
 
 	make_purchase_order(){
-		let pending_items = this.frm.doc.items.some((item) =>{
-			let pending_qty = flt(item.stock_qty) - flt(item.ordered_qty);
-			return pending_qty > 0;
-		})
-		if(!pending_items){
-			frappe.throw({message: __("Purchase Order already created for all Sales Order items"), title: __("Note")});
-		}
-
 		var me = this;
 		var dialog = new frappe.ui.Dialog({
 			title: __("Select Items"),
@@ -716,8 +708,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			} else {
 				let po_items = [];
 				me.frm.doc.items.forEach(d => {
-					let ordered_qty = me.get_ordered_qty(d, me.frm.doc);
-					let pending_qty = (flt(d.stock_qty) - ordered_qty) / flt(d.conversion_factor);
+					let pending_qty = flt(d.stock_qty) / flt(d.conversion_factor);
 					if (pending_qty > 0) {
 						po_items.push({
 							"doctype": "Sales Order Item",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -939,8 +939,8 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 
 	def update_item(source, target, source_parent):
 		target.schedule_date = source.delivery_date
-		target.qty = flt(source.qty) - (flt(source.ordered_qty) / flt(source.conversion_factor))
-		target.stock_qty = flt(source.stock_qty) - flt(source.ordered_qty)
+		target.qty = flt(source.qty)
+		target.stock_qty = flt(source.stock_qty)
 		target.project = source_parent.project
 
 	suppliers = [item.get("supplier") for item in selected_items if item.get("supplier")]
@@ -993,8 +993,7 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 						"pricing_rules",
 					],
 					"postprocess": update_item,
-					"condition": lambda doc: doc.ordered_qty < doc.stock_qty
-					and doc.supplier == supplier
+					"condition": lambda doc: doc.supplier == supplier
 					and doc.item_code in items_to_map,
 				},
 			},
@@ -1053,12 +1052,12 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 
 	def update_item(source, target, source_parent):
 		target.schedule_date = source.delivery_date
-		target.qty = flt(source.qty) - (flt(source.ordered_qty) / flt(source.conversion_factor))
-		target.stock_qty = flt(source.stock_qty) - flt(source.ordered_qty)
+		target.qty = flt(source.qty)
+		target.stock_qty = flt(source.stock_qty)
 		target.project = source_parent.project
 
 	def update_item_for_packed_item(source, target, source_parent):
-		target.qty = flt(source.qty) - flt(source.ordered_qty)
+		target.qty = flt(source.qty)
 
 	# po = frappe.get_list("Purchase Order", filters={"sales_order":source_name, "supplier":supplier, "docstatus": ("<", "2")})
 	doc = get_mapped_doc(
@@ -1099,8 +1098,7 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 					"pricing_rules",
 				],
 				"postprocess": update_item,
-				"condition": lambda doc: doc.ordered_qty < doc.stock_qty
-				and doc.item_code in items_to_map
+				"condition": lambda doc: doc.item_code in items_to_map
 				and not is_product_bundle(doc.item_code),
 			},
 			"Packed Item": {


### PR DESCRIPTION
**Problem:**

After submitting a sales order, When I try to create a purchase order from that sales order, it gives an error "Purchase Order already created for all Sales Order items".

But actually no purchase order has been created against this sales order.

![image](https://user-images.githubusercontent.com/13396535/235445050-881c639f-617b-407a-8da0-2fcebc59f0b4.png)

**Solution:**

Suppress the validation logic and allow new Purchase Orders to made against the Sales Order, irrespective of existing POs against the item.