### PR TITLE
fix: exclude sourced by hyper if Exploded Items are fetched

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -383,7 +383,9 @@ class SubcontractingController(StockController):
 			"sourced_by_supplier",
 			"sourced_by_hyper",
 		]:
-			fields.append(f"`tab{doctype}`.`{field}` As {alias_dict.get(field, field)}")
+			#TODO Add sourced_by_hyper in BOM Explosion Item if needed, exclude for now.
+			if not (field == "sourced_by_hyper" and doctype == "BOM Explosion Item"):
+				fields.append(f"`tab{doctype}`.`{field}` As {alias_dict.get(field, field)}")
 
 		filters = [
 			[doctype, "parent", "=", bom_no],


### PR DESCRIPTION
Exclude sourced by hyper if Exploded Items are fetched, as `sourced_by_hyper` does not exist in `BOM Explosion Item` 
