### PR TITLE
fix: validation for creating Purchase invoice from Purchase Order (#8) [CU-868578pha]

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -418,7 +418,7 @@ class PurchaseInvoice(BuyingController):
 					},
 					"sum(qty) as qty"
 				)
-				existing_invoiced_qty = invoiced_items[0].get("qty") if len(invoiced_items) > 0 else 0
+				existing_invoiced_qty = invoiced_items[0].get("qty") or 0
 
 				if (d.qty + existing_invoiced_qty) > received_qty:
 					frappe.throw(f"Row #{d.idx}: Invoiced quantity cannot be greater than the received quantity for {frappe.bold(d.item_code)}")

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -627,7 +627,7 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 				},
 				"sum(qty) as qty"
 			)
-			existing_invoiced_qty = invoiced_items[0].get("qty") if len(invoiced_items) > 0 else 0
+			existing_invoiced_qty = invoiced_items[0].get("qty") or 0
 
 			item.qty = received_qty - existing_invoiced_qty
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -613,6 +613,24 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 		postprocess,
 		ignore_permissions=ignore_permissions,
 	)
+
+	#set remaning qty to be invoiced against received qty
+	if frappe.db.get_single_value("Buying Settings", "pr_required") == "Yes":
+		for item in doc.get("items"):
+			received_qty = frappe.db.get_value("Purchase Order Item", item.po_detail, "received_qty")
+			invoiced_items = frappe.get_all(
+				"Purchase Invoice Item",
+				{
+					"po_detail": item.po_detail,
+					"item_code": item.item_code,
+					"docstatus": 1
+				},
+				"sum(qty) as qty"
+			)
+			existing_invoiced_qty = invoiced_items[0].get("qty") if len(invoiced_items) > 0 else 0
+
+			item.qty = received_qty - existing_invoiced_qty
+
 	doc.set_onload("ignore_price_list", True)
 
 	return doc


### PR DESCRIPTION
validation for creating Purchase invoice from Purchase Order
If `Purchase Receipt Required for Purchase Invoice Creation` is `Yes` in `Buying Settings` then It allows to create Purchase Invoice from Purchase Order for the quantity which is received and not billed.