### PR TITLE
fix: validate direct invoice creation without order or receipt

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -409,6 +409,9 @@ class PurchaseInvoice(BuyingController):
 				return
 
 			for d in self.get("items"):
+				if not d.po_detail:
+					frappe.throw("Please create the invoice from an existing Purchase Order or Receipt instead.")
+
 				received_qty = frappe.db.get_value("Purchase Order Item", d.po_detail, "received_qty")
 				invoiced_items = frappe.get_all("Purchase Invoice Item",
 					{
@@ -420,7 +423,7 @@ class PurchaseInvoice(BuyingController):
 				)
 				existing_invoiced_qty = invoiced_items[0].get("qty") or 0
 
-				if (d.qty + existing_invoiced_qty) > received_qty:
+				if (d.qty + existing_invoiced_qty) > flt(received_qty):
 					frappe.throw(f"Row #{d.idx}: Invoiced quantity cannot be greater than the received quantity for {frappe.bold(d.item_code)}")
 
 			# if not d.purchase_receipt and d.item_code in stock_items:

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -400,7 +400,7 @@ class PurchaseInvoice(BuyingController):
 					throw(msg, title=_("Mandatory Purchase Order"))
 
 	def pr_required(self):
-		# stock_items = self.get_stock_items()
+		stock_items = self.get_stock_items()
 		if frappe.db.get_value("Buying Settings", None, "pr_required") == "Yes":
 
 			if frappe.get_value(
@@ -409,22 +409,23 @@ class PurchaseInvoice(BuyingController):
 				return
 
 			for d in self.get("items"):
-				if not d.po_detail:
-					frappe.throw("Please create the invoice from an existing Purchase Order or Receipt instead.")
+				if d.item_code in stock_items:
+					if not d.po_detail:
+						frappe.throw("Please create the invoice from an existing Purchase Order or Receipt instead.")
 
-				received_qty = frappe.db.get_value("Purchase Order Item", d.po_detail, "received_qty")
-				invoiced_items = frappe.get_all("Purchase Invoice Item",
-					{
-						"po_detail": d.po_detail,
-						"item_code": d.item_code,
-						"docstatus": 1
-					},
-					"sum(qty) as qty"
-				)
-				existing_invoiced_qty = invoiced_items[0].get("qty") or 0
+					received_qty = frappe.db.get_value("Purchase Order Item", d.po_detail, "received_qty")
+					invoiced_items = frappe.get_all("Purchase Invoice Item",
+						{
+							"po_detail": d.po_detail,
+							"item_code": d.item_code,
+							"docstatus": 1
+						},
+						"sum(qty) as qty"
+					)
+					existing_invoiced_qty = invoiced_items[0].get("qty") or 0
 
-				if (d.qty + existing_invoiced_qty) > flt(received_qty):
-					frappe.throw(f"Row #{d.idx}: Invoiced quantity cannot be greater than the received quantity for {frappe.bold(d.item_code)}")
+					if (d.qty + existing_invoiced_qty) > flt(received_qty):
+						frappe.throw(f"Row #{d.idx}: Invoiced quantity cannot be greater than the received quantity for {frappe.bold(d.item_code)}")
 
 			# if not d.purchase_receipt and d.item_code in stock_items:
 			# 	msg = _("Purchase Receipt Required for item {}").format(frappe.bold(d.item_code))


### PR DESCRIPTION
If Is `Purchase Receipt Required for Purchase Invoice Creation?` is `No` in `Buying Settings` it will allow user to create Plain invoice without any order or receipt, but if `Yes`, then It validates and does not allow an invoice creation without Order or Receipt.